### PR TITLE
Add support for Linux arm64 binaries

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -47,7 +47,7 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt update
-            apt install python3
+            apt install python3 -y
             pip install .
 
             # aliens: requires no source

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -59,39 +59,38 @@ jobs:
             ALIENS_PATH=${PWD}/${ALIENS_NAME}
             # packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
 
-            # # textual: requires no source
-            # TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
-            # TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
-            # packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
+            # textual: requires no source
+            TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
+            TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
+            packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
 
-            # # IPython: requires no source
-            # IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
-            # IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
-            # packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
+            # IPython: requires no source
+            IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
+            IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
+            packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
 
-            # # ./examples/mandelbrot
-            # MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
-            # MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
-            # packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
+            # ./examples/mandelbrot
+            MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
+            MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
+            packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
 
-            # # ./examples/minesweeper
-            # MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
-            # MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
-            # packaged ./example/minesweeper
-            # mv ./minesweeper.bin $MINESWEEPER_NAME
+            # ./examples/minesweeper
+            MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
+            MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
+            packaged ./example/minesweeper
+            mv ./minesweeper.bin $MINESWEEPER_NAME
 
             # Setup output paths for upload
-            GITHUB_OUTPUT=""
-            echo "ALIENS_NAME=${ALIENS_NAME}" >> "${GITHUB_OUTPUT}"
-            echo "ALIENS_PATH=${ALIENS_PATH}" >> "${GITHUB_OUTPUT}"
-            # echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
-            # echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
-            # echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT
-            # echo "IPYTHON_PATH=${IPYTHON_PATH}" >> $GITHUB_OUTPUT
-            # echo "MANDELBROT_NAME=${MANDELBROT_NAME}" >> $GITHUB_OUTPUT
-            # echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
-            # echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
-            # echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
+            echo ::set-output name=ALIENS_NAME::"${ALIENS_NAME}"
+            echo ::set-output name=ALIENS_PATH::"${ALIENS_PATH}"
+            echo ::set-output name=TEXTUAL_NAME::"${TEXTUAL_NAME}"
+            echo ::set-output name=TEXTUAL_PATH::"${TEXTUAL_PATH}"
+            echo ::set-output name=IPYTHON_NAME::"${IPYTHON_NAME}"
+            echo ::set-output name=IPYTHON_PATH::"${IPYTHON_PATH}"
+            echo ::set-output name=MANDELBROT_NAME::"${MANDELBROT_NAME}"
+            echo ::set-output name=MANDELBROT_PATH::"${MANDELBROT_PATH}"
+            echo ::set-output name=MINESWEEPER_NAME::"${MINESWEEPER_NAME}"
+            echo ::set-output name=MINESWEEPER_PATH::"${MINESWEEPER_PATH}"
 
       - run: echo github output is $GITHUB_OUTPUT
 
@@ -101,29 +100,29 @@ jobs:
           name: ${{ steps.build.outputs.ALIENS_NAME }}
           path: ${{ steps.build.outputs.ALIENS_PATH }}
 
-      # - name: Upload textual
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ steps.build.outputs.TEXTUAL_NAME }}
-      #     path: ${{ steps.build.outputs.TEXTUAL_PATH }}
+      - name: Upload textual
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.TEXTUAL_NAME }}
+          path: ${{ steps.build.outputs.TEXTUAL_PATH }}
 
-      # - name: Upload IPython
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ steps.build.outputs.IPYTHON_NAME }}
-      #     path: ${{ steps.build.outputs.IPYTHON_PATH }}
+      - name: Upload IPython
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.IPYTHON_NAME }}
+          path: ${{ steps.build.outputs.IPYTHON_PATH }}
 
-      # - name: Upload mandelbrot
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ steps.build.outputs.MANDELBROT_NAME }}
-      #     path: ${{ steps.build.outputs.MANDELBROT_PATH }}
+      - name: Upload mandelbrot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.MANDELBROT_NAME }}
+          path: ${{ steps.build.outputs.MANDELBROT_PATH }}
 
-      # - name: Upload minesweeper
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ steps.build.outputs.MINESWEEPER_NAME }}
-      #     path: ${{ steps.build.outputs.MINESWEEPER_PATH }}
+      - name: Upload minesweeper
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.MINESWEEPER_NAME }}
+          path: ${{ steps.build.outputs.MINESWEEPER_PATH }}
 
       - name: Publish packages
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -47,7 +47,7 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt update
-            apt install python3 -y
+            apt install python3-pip -y
             pip install .
 
             # aliens: requires no source

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -36,24 +36,19 @@ jobs:
           unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install packaged
-        run: |
-          pip install .
-
       - uses: uraimo/run-on-arch-action@v2
         name: Build binary under QEMU
         id: build
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
           githubToken: ${{ github.token }}
           run: |
+            apt install python3
+            pip install .
+
             # aliens: requires no source
             ALIENS_NAME="aliens-${{ matrix.target }}.bin"
             ALIENS_PATH=${PWD}/${ALIENS_NAME}

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -57,7 +57,7 @@ jobs:
             # aliens: requires no source
             ALIENS_NAME="aliens-${{ matrix.target }}.bin"
             ALIENS_PATH=${PWD}/${ALIENS_NAME}
-            packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
+            # packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
 
             # # textual: requires no source
             # TEXTUAL_NAME="textual-${{ matrix.target }}.bin"

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -59,38 +59,38 @@ jobs:
             ALIENS_PATH=${PWD}/${ALIENS_NAME}
             packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
 
-            # textual: requires no source
-            TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
-            TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
-            packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
+            # # textual: requires no source
+            # TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
+            # TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
+            # packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
 
-            # IPython: requires no source
-            IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
-            IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
-            packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
+            # # IPython: requires no source
+            # IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
+            # IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
+            # packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
 
-            # ./examples/mandelbrot
-            MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
-            MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
-            packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
+            # # ./examples/mandelbrot
+            # MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
+            # MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
+            # packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
 
-            # ./examples/minesweeper
-            MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
-            MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
-            packaged ./example/minesweeper
-            mv ./minesweeper.bin $MINESWEEPER_NAME
+            # # ./examples/minesweeper
+            # MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
+            # MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
+            # packaged ./example/minesweeper
+            # mv ./minesweeper.bin $MINESWEEPER_NAME
 
             # Setup output paths for upload
             echo "ALIENS_NAME=${ALIENS_NAME}" >> $GITHUB_OUTPUT
             echo "ALIENS_PATH=${ALIENS_PATH}" >> $GITHUB_OUTPUT
-            echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
-            echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
-            echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT
-            echo "IPYTHON_PATH=${IPYTHON_PATH}" >> $GITHUB_OUTPUT
-            echo "MANDELBROT_NAME=${MANDELBROT_NAME}" >> $GITHUB_OUTPUT
-            echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
-            echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
-            echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
+            # echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
+            # echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
+            # echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT
+            # echo "IPYTHON_PATH=${IPYTHON_PATH}" >> $GITHUB_OUTPUT
+            # echo "MANDELBROT_NAME=${MANDELBROT_NAME}" >> $GITHUB_OUTPUT
+            # echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
+            # echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
+            # echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload aliens
         uses: actions/upload-artifact@v4
@@ -98,29 +98,29 @@ jobs:
           name: ${{ steps.build.outputs.ALIENS_NAME }}
           path: ${{ steps.build.outputs.ALIENS_PATH }}
 
-      - name: Upload textual
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.build.outputs.TEXTUAL_NAME }}
-          path: ${{ steps.build.outputs.TEXTUAL_PATH }}
+      # - name: Upload textual
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ steps.build.outputs.TEXTUAL_NAME }}
+      #     path: ${{ steps.build.outputs.TEXTUAL_PATH }}
 
-      - name: Upload IPython
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.build.outputs.IPYTHON_NAME }}
-          path: ${{ steps.build.outputs.IPYTHON_PATH }}
+      # - name: Upload IPython
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ steps.build.outputs.IPYTHON_NAME }}
+      #     path: ${{ steps.build.outputs.IPYTHON_PATH }}
 
-      - name: Upload mandelbrot
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.build.outputs.MANDELBROT_NAME }}
-          path: ${{ steps.build.outputs.MANDELBROT_PATH }}
+      # - name: Upload mandelbrot
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ steps.build.outputs.MANDELBROT_NAME }}
+      #     path: ${{ steps.build.outputs.MANDELBROT_PATH }}
 
-      - name: Upload minesweeper
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.build.outputs.MINESWEEPER_NAME }}
-          path: ${{ steps.build.outputs.MINESWEEPER_PATH }}
+      # - name: Upload minesweeper
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ steps.build.outputs.MINESWEEPER_NAME }}
+      #     path: ${{ steps.build.outputs.MINESWEEPER_PATH }}
 
       - name: Publish packages
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -46,6 +46,7 @@ jobs:
           # a GitHub package registry.
           githubToken: ${{ github.token }}
           run: |
+            apt update
             apt install python3
             pip install .
 

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -82,8 +82,8 @@ jobs:
 
             # Setup output paths for upload
             GITHUB_OUTPUT=""
-            echo "ALIENS_NAME=${ALIENS_NAME}" >> $GITHUB_OUTPUT
-            echo "ALIENS_PATH=${ALIENS_PATH}" >> $GITHUB_OUTPUT
+            echo "ALIENS_NAME=${ALIENS_NAME}" >> "${GITHUB_OUTPUT}"
+            echo "ALIENS_PATH=${ALIENS_PATH}" >> "${GITHUB_OUTPUT}"
             # echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
             # echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
             # echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -24,14 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "Linux-x86_64", target: x86_64-linux, os: ubuntu-20.04 }
-          - { name: "macOS-x86_64", target: x86_64-darwin, os: macOS-13 }
-          - { name: "macOS-aarch64", target: aarch64-darwin, os: macOS-14 }
-          # - {
-          #     name: "windows-x86_64",
-          #     target: x86_64-windows,
-          #     os: windows-latest,
-          #   }
+          - { name: "Linux-aarch64", target: aarch64-linux, os: ubuntu-20.04 }
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -51,47 +44,53 @@ jobs:
         run: |
           pip install .
 
-      - name: Build binary
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build binary under QEMU
         id: build
-        shell: bash
-        run: |
-          # aliens: requires no source
-          ALIENS_NAME="aliens-${{ matrix.target }}.bin"
-          ALIENS_PATH=${PWD}/${ALIENS_NAME}
-          packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+          run: |
+            # aliens: requires no source
+            ALIENS_NAME="aliens-${{ matrix.target }}.bin"
+            ALIENS_PATH=${PWD}/${ALIENS_NAME}
+            packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
 
-          # textual: requires no source
-          TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
-          TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
-          packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
+            # textual: requires no source
+            TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
+            TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
+            packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
 
-          # IPython: requires no source
-          IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
-          IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
-          packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
+            # IPython: requires no source
+            IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
+            IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
+            packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
 
-          # ./examples/mandelbrot
-          MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
-          MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
-          packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
+            # ./examples/mandelbrot
+            MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
+            MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
+            packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
 
-          # ./examples/minesweeper
-          MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
-          MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
-          packaged ./example/minesweeper
-          mv ./minesweeper.bin $MINESWEEPER_NAME
+            # ./examples/minesweeper
+            MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
+            MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
+            packaged ./example/minesweeper
+            mv ./minesweeper.bin $MINESWEEPER_NAME
 
-          # Setup output paths for upload
-          echo "ALIENS_NAME=${ALIENS_NAME}" >> $GITHUB_OUTPUT
-          echo "ALIENS_PATH=${ALIENS_PATH}" >> $GITHUB_OUTPUT
-          echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
-          echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
-          echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT
-          echo "IPYTHON_PATH=${IPYTHON_PATH}" >> $GITHUB_OUTPUT
-          echo "MANDELBROT_NAME=${MANDELBROT_NAME}" >> $GITHUB_OUTPUT
-          echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
-          echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
-          echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
+            # Setup output paths for upload
+            echo "ALIENS_NAME=${ALIENS_NAME}" >> $GITHUB_OUTPUT
+            echo "ALIENS_PATH=${ALIENS_PATH}" >> $GITHUB_OUTPUT
+            echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
+            echo "TEXTUAL_PATH=${TEXTUAL_PATH}" >> $GITHUB_OUTPUT
+            echo "IPYTHON_NAME=${IPYTHON_NAME}" >> $GITHUB_OUTPUT
+            echo "IPYTHON_PATH=${IPYTHON_PATH}" >> $GITHUB_OUTPUT
+            echo "MANDELBROT_NAME=${MANDELBROT_NAME}" >> $GITHUB_OUTPUT
+            echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
+            echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
+            echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload aliens
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -81,6 +81,7 @@ jobs:
             # mv ./minesweeper.bin $MINESWEEPER_NAME
 
             # Setup output paths for upload
+            GITHUB_OUTPUT=""
             echo "ALIENS_NAME=${ALIENS_NAME}" >> $GITHUB_OUTPUT
             echo "ALIENS_PATH=${ALIENS_PATH}" >> $GITHUB_OUTPUT
             # echo "TEXTUAL_NAME=${TEXTUAL_NAME}" >> $GITHUB_OUTPUT
@@ -91,6 +92,8 @@ jobs:
             # echo "MANDELBROT_PATH=${MANDELBROT_PATH}" >> $GITHUB_OUTPUT
             # echo "MINESWEEPER_NAME=${MINESWEEPER_NAME}" >> $GITHUB_OUTPUT
             # echo "MINESWEEPER_PATH=${MINESWEEPER_PATH}" >> $GITHUB_OUTPUT
+
+      - run: echo github output is $GITHUB_OUTPUT
 
       - name: Upload aliens
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -45,10 +45,6 @@ jobs:
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
           githubToken: ${{ github.token }}
-          # workaround for $GITHUB_OUTPUT not available in run-on-arch:
-          # https://github.com/uraimo/run-on-arch-action/issues/52
-          dockerRunArgs: |
-            --volume /home/runner/work/_temp:/home/runner/work/_temp
           run: |
             apt update
             apt install python3-pip -y
@@ -91,8 +87,6 @@ jobs:
             echo ::set-output name=MANDELBROT_PATH::"${MANDELBROT_PATH}"
             echo ::set-output name=MINESWEEPER_NAME::"${MINESWEEPER_NAME}"
             echo ::set-output name=MINESWEEPER_PATH::"${MINESWEEPER_PATH}"
-
-      - run: echo github output is $GITHUB_OUTPUT
 
       - name: Upload aliens
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -45,6 +45,10 @@ jobs:
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
           githubToken: ${{ github.token }}
+          # workaround for $GITHUB_OUTPUT not available in run-on-arch:
+          # https://github.com/uraimo/run-on-arch-action/issues/52
+          dockerRunArgs: |
+            --volume /home/runner/work/_temp:/home/runner/work/_temp
           run: |
             apt update
             apt install python3-pip -y

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -1,4 +1,4 @@
-name: Build binaries for all platforms
+name: Build binaries for platforms under QEMU
 
 on:
   push:
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-cross:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
       - uses: uraimo/run-on-arch-action@v2
-        if: ${{ matrix.name }} == "Linux-aarch64"
+        if: matrix.name == "Linux-aarch64"
         name: Setup qemu to build for unavailable platform
         id: runcmd
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         id: runcmd
         with:
           arch: aarch64
-          distro: ${{ matrix.os }}
+          distro: ubuntu20.04
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
           githubToken: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
       - uses: uraimo/run-on-arch-action@v2
-        if: matrix.name == "Linux-aarch64"
+        if: matrix.name == 'Linux-aarch64'
         name: Setup qemu to build for unavailable platform
         id: runcmd
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           - { name: "Linux-x86_64", target: x86_64-linux, os: ubuntu-20.04 }
           # No arm linux OS available on github actions.
           # Find another way.
-          # - { name: "Linux-aarch64", target: aarch64-linux, os: ubuntu-latest }
+          - { name: "Linux-aarch64", target: aarch64-linux, os: ubuntu-20.04 }
           - { name: "macOS-x86_64", target: x86_64-darwin, os: macOS-13 }
           - { name: "macOS-aarch64", target: aarch64-darwin, os: macOS-14 }
           # - {
@@ -45,6 +45,17 @@ jobs:
         run: |
           unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
+
+      - uses: uraimo/run-on-arch-action@v2
+        if: ${{ matrix.name }} == "Linux-aarch64"
+        name: Setup qemu to build for unavailable platform
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ${{ matrix.os }}
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - { python-version: "3.8", tox-env: "py38" }
+          - { python-version: "3.9", tox-env: "py39" }
+          - { python-version: "3.10", tox-env: "py310" }
+          - { python-version: "3.11", tox-env: "py311" }
+          - { python-version: "3.12", tox-env: "py312" }
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v2
@@ -23,4 +28,4 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Run tests and type checking
-        run: tox
+        run: tox -e ${{matrix.tox-env }}


### PR DESCRIPTION
Using the "Run on architecture" action that uses QEMU, we can build binaries for pretty much any arch. Let's start with Linux on arm64.