### PR TITLE
Add flag to disable output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,27 +61,27 @@ jobs:
           # aliens: requires no source
           ALIENS_NAME="aliens-${{ matrix.target }}.bin"
           ALIENS_PATH=${PWD}/${ALIENS_NAME}
-          packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens' --quiet
+          packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
 
           # textual: requires no source
           TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
           TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
-          packaged $TEXTUAL_NAME 'pip install textual' 'python -m textual' --quiet
+          packaged $TEXTUAL_NAME 'pip install textual' 'python -m textual'
 
           # IPython: requires no source
           IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
           IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
-          packaged $IPYTHON_NAME 'pip install ipython' 'ipython' --quiet
+          packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
 
           # ./examples/mandelbrot
           MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
           MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
-          packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot --quiet
+          packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
 
           # ./examples/minesweeper
           MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
           MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
-          packaged ./example/minesweeper --quiet
+          packaged ./example/minesweeper
           mv ./minesweeper.bin $MINESWEEPER_NAME
 
           # Setup output paths for upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,27 +61,27 @@ jobs:
           # aliens: requires no source
           ALIENS_NAME="aliens-${{ matrix.target }}.bin"
           ALIENS_PATH=${PWD}/${ALIENS_NAME}
-          packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens'
+          packaged $ALIENS_NAME 'pip install pygame' 'python -m pygame.examples.aliens' --quiet
 
           # textual: requires no source
           TEXTUAL_NAME="textual-${{ matrix.target }}.bin"
           TEXTUAL_PATH=${PWD}/${TEXTUAL_NAME}
-          packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual'
+          packaged $TEXTUAL_NAME 'pip install pygame' 'python -m textual' --quiet
 
           # IPython: requires no source
           IPYTHON_NAME="ipython-${{ matrix.target }}.bin"
           IPYTHON_PATH=${PWD}/${IPYTHON_NAME}
-          packaged $IPYTHON_NAME 'pip install ipython' 'ipython'
+          packaged $IPYTHON_NAME 'pip install ipython' 'ipython' --quiet
 
           # ./examples/mandelbrot
           MANDELBROT_NAME="mandelbrot-${{ matrix.target }}.bin"
           MANDELBROT_PATH=${PWD}/${MANDELBROT_NAME}
-          packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot
+          packaged $MANDELBROT_NAME 'pip install -r requirements.txt' 'python mandelbrot.py' ./example/mandelbrot --quiet
 
           # ./examples/minesweeper
           MINESWEEPER_NAME="minesweeper-${{ matrix.target }}.bin"
           MINESWEEPER_PATH=${PWD}/${MINESWEEPER_NAME}
-          packaged ./example/minesweeper
+          packaged ./example/minesweeper --quiet
           mv ./minesweeper.bin $MINESWEEPER_NAME
 
           # Setup output paths for upload

--- a/src/packaged/__init__.py
+++ b/src/packaged/__init__.py
@@ -7,10 +7,14 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from typing import cast, TYPE_CHECKING
 from unittest import mock
 
 import yen.github
 from yaspin import yaspin
+
+if TYPE_CHECKING:
+    from yaspin.core import Yaspin
 
 MAKESELF_PATH = os.path.join(os.path.dirname(__file__), "makeself.sh")
 DEFAULT_PYTHON_VERSION = "3.12"
@@ -73,7 +77,7 @@ def create_package(
         # Run the build command in the source directory, while making sure
         # that `python` and related binaries point to the installed python
         if quiet:
-            spinner = mock.Mock()
+            spinner = cast("Yaspin", mock.Mock())
         else:
             spinner = yaspin(text="Running the build command...")
 

--- a/src/packaged/__init__.py
+++ b/src/packaged/__init__.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from unittest import mock
 
 import yen.github
 from yaspin import yaspin
@@ -38,6 +39,7 @@ def create_package(
     build_command: str,
     startup_command: str,
     python_version: str,
+    quiet: bool = False,
 ) -> None:
     """Create the makeself executable, with the startup script in it."""
     if source_directory is None:
@@ -70,7 +72,11 @@ def create_package(
 
         # Run the build command in the source directory, while making sure
         # that `python` and related binaries point to the installed python
-        spinner = yaspin(text="Running the build command...")
+        if quiet:
+            spinner = mock.Mock()
+        else:
+            spinner = yaspin(text="Running the build command...")
+
         spinner.start()
         try:
             subprocess.run(
@@ -177,7 +183,9 @@ def create_package(
 
     finally:
         spinner.stop()
-        print(f"Package {output_path!r} built successfully!")
+        if not quiet:
+            print(f"Package {output_path!r} built successfully!")
+
         # Cleanup the packaged python and startup script from source directory
         if os.path.exists(startup_script_path):
             os.remove(startup_script_path)

--- a/src/packaged/cli.py
+++ b/src/packaged/cli.py
@@ -70,7 +70,8 @@ def cli(argv: list[str] | None = None) -> int:
         parser.add_argument(
             "--quiet",
             help="Disable all output",
-            action="store_false" if "CI" in os.environ else "store_true",
+            action="store_true",
+            default="CI" in os.environ,
         )
         args = parser.parse_args(argv)
         config = Config(**vars(args))

--- a/src/packaged/cli.py
+++ b/src/packaged/cli.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import os.path
 import platform
 import sys
-import typing
 
 from packaged import (
     DEFAULT_PYTHON_VERSION,
@@ -69,6 +67,11 @@ def cli(argv: list[str] | None = None) -> int:
             help="Version of Python to package your project with.",
             default=DEFAULT_PYTHON_VERSION,
         )
+        parser.add_argument(
+            "--quiet",
+            help="Disable all output",
+            action="store_true",
+        )
         args = parser.parse_args(argv)
         config = Config(**vars(args))
 
@@ -79,6 +82,7 @@ def cli(argv: list[str] | None = None) -> int:
             config.build_command,
             config.startup_command,
             config.python_version,
+            config.quiet,
         )
     except SourceDirectoryNotFound as exc:
         error(f"Folder {exc.directory_path!r} does not exist.")

--- a/src/packaged/cli.py
+++ b/src/packaged/cli.py
@@ -70,7 +70,7 @@ def cli(argv: list[str] | None = None) -> int:
         parser.add_argument(
             "--quiet",
             help="Disable all output",
-            action="store_true",
+            action="store_false" if "CI" in os.environ else "store_true",
         )
         args = parser.parse_args(argv)
         config = Config(**vars(args))

--- a/src/packaged/config.py
+++ b/src/packaged/config.py
@@ -55,6 +55,7 @@ def parse_config(source_directory: str) -> Config:
             config_data["build_command"],
             config_data["startup_command"],
             config_data.get("python_version", "3.12"),
+            config_data.get("quiet", "CI" in os.environ),
         )
     except KeyError as exc:
         key = exc.args[0]

--- a/src/packaged/config.py
+++ b/src/packaged/config.py
@@ -25,6 +25,7 @@ class Config:
     build_command: str
     startup_command: str
     python_version: str
+    quiet: bool
 
 
 CONFIG_NAME = "./packaged.toml"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -18,6 +18,7 @@ def test_cli() -> None:
         "pip install foo",
         "python -m foo",
         packaged.DEFAULT_PYTHON_VERSION,
+        False,
     )
 
     with mock.patch.object(packaged.cli, "create_package") as mocked:
@@ -26,7 +27,9 @@ def test_cli() -> None:
         )
 
     # specified python version
-    mocked.assert_called_with(None, "./baz", "pip install baz", "python -m baz", "3.10")
+    mocked.assert_called_with(
+        None, "./baz", "pip install baz", "python -m baz", "3.10", False
+    )
 
     with mock.patch.object(packaged.cli, "create_package") as mocked:
         packaged.cli.cli(
@@ -45,6 +48,23 @@ def test_cli() -> None:
         "pip install -rrequirements.txt",
         "python src/mypackage/cli.py",
         packaged.DEFAULT_PYTHON_VERSION,
+        False,
     )
     args = mocked.call_args[0]
     assert args[0].endswith("/mypackage")
+
+    # Test --quiet
+    with mock.patch.object(packaged.cli, "create_package") as mocked:
+        packaged.cli.cli(
+            ["./some", "pip install some", "python some.py", "./some.bin", "--quiet"]
+        )
+
+    # quiet is True
+    mocked.assert_called_with(
+        mock.ANY,
+        "./some",
+        "pip install some",
+        "python some.py",
+        packaged.DEFAULT_PYTHON_VERSION,
+        True,
+    )


### PR DESCRIPTION
Adds a `--quiet` flag which disables the spinner (and any other stdout output).

`--quiet` is implied when `CI` envvar is set.