### PR TITLE
Error out if output path already exists

### DIFF
--- a/src/packaged/__init__.py
+++ b/src/packaged/__init__.py
@@ -37,6 +37,10 @@ class PythonNotAvailable(Exception):
         self.python_version = python_version
 
 
+class OutputPathExists(Exception):
+    """Raised when the output path already exists."""
+
+
 def create_package(
     source_directory: str | None,
     output_path: str,
@@ -46,6 +50,9 @@ def create_package(
     quiet: bool = False,
 ) -> None:
     """Create the makeself executable, with the startup script in it."""
+    if os.path.exists(output_path):
+        raise OutputPathExists
+
     if source_directory is None:
         source_directory = tempfile.mkdtemp()
 

--- a/src/packaged/cli.py
+++ b/src/packaged/cli.py
@@ -9,6 +9,7 @@ import sys
 
 from packaged import (
     DEFAULT_PYTHON_VERSION,
+    OutputPathExists,
     PythonNotAvailable,
     SourceDirectoryNotFound,
     create_package,
@@ -23,7 +24,7 @@ from packaged.config import (
 
 def error(message: str) -> None:
     """Print error message"""
-    print(f"\033[1;31mError:\033[m {message}")
+    print(f"\033[1;31mError:\033[m {message}", file=sys.stderr)
 
 
 def cli(argv: list[str] | None = None) -> int:
@@ -91,5 +92,11 @@ def cli(argv: list[str] | None = None) -> int:
     except PythonNotAvailable as exc:
         error(f"Python {exc.python_version!r} is not available for download.")
         return 5
+    except OutputPathExists:
+        err_msg = f"output path {config.output_path!r} already exists"
+        if config.output_path == ".":
+            err_msg += "\nConsider giving a filename, like './myapp.bin'"
+        error(err_msg)
+        return 6
 
     return 0


### PR DESCRIPTION
```console
$ packaged ./aliens.bin 'pip install foo' 'python -m foo' 
Error: output path './aliens.bin' already exists

$ packaged . 'pip install foo' 'python -m foo'
Error: output path '.' already exists
Consider giving a filename, like './myapp.bin'
```