### PR TITLE
feat: integrate pycify

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packaged
-version = 0.5.4
+version = 0.6.0
 description = The easiest way to ship python applications.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -28,7 +28,7 @@ install_requires =
     yen>=0.4.2
     tomli>=1.1.0; python_version<'3.11'
     yaspin>=2.5.0
-    pycify>=1.1.1
+    pycify>=1.2.0
 python_requires = >=3.8
 package_dir = =src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packaged
-version = 0.5.3
+version = 0.5.4
 description = The easiest way to ship python applications.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -28,6 +28,7 @@ install_requires =
     yen>=0.4.2
     tomli>=1.1.0; python_version<'3.11'
     yaspin>=2.5.0
+    pycify>=1.1.1
 python_requires = >=3.8
 package_dir = =src
 

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/src/packaged/__init__.py
+++ b/src/packaged/__init__.py
@@ -13,6 +13,8 @@ from unittest import mock
 import yen.github
 from yaspin import yaspin
 
+from pycify import replace_py_with_pyc
+
 if TYPE_CHECKING:
     from yaspin.core import Yaspin
 
@@ -48,6 +50,8 @@ def create_package(
     startup_command: str,
     python_version: str,
     quiet: bool = False,
+    pyc: bool = False,
+    ignore_file_patterns: list[str] | None = None,
 ) -> None:
     """Create the makeself executable, with the startup script in it."""
     if os.path.exists(output_path):
@@ -58,6 +62,17 @@ def create_package(
 
     if not os.path.isdir(source_directory):
         raise SourceDirectoryNotFound(source_directory)
+
+    if pyc:
+        created_pyc_files = replace_py_with_pyc(
+            source_directory,
+            python_version=python_version,
+            ignore_file_patterns=ignore_file_patterns,
+        )
+        if not created_pyc_files:
+            print("No .pyc files were created.", file=sys.stderr)
+        else:
+            print(f"Created {len(created_pyc_files)} .pyc files.")
 
     startup_script_name = "_packaged_startup.sh"
     startup_script_path = os.path.join(source_directory, startup_script_name)

--- a/src/packaged/__main__.py
+++ b/src/packaged/__main__.py
@@ -1,4 +1,5 @@
 """Support executing the CLI by doing `python -m packaged`."""
+
 from __future__ import annotations
 
 from packaged.cli import cli

--- a/src/packaged/cli.py
+++ b/src/packaged/cli.py
@@ -74,6 +74,18 @@ def cli(argv: list[str] | None = None) -> int:
             action="store_true",
             default="CI" in os.environ,
         )
+        parser.add_argument(
+            "--pyc",
+            help="Replace .py files with .pyc files",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "--ignore-file-patterns",
+            help="List of file patterns to ignore when using --pyc",
+            nargs="+",
+            default=["setup.py"],
+        )
         args = parser.parse_args(argv)
         config = Config(**vars(args))
 
@@ -85,6 +97,8 @@ def cli(argv: list[str] | None = None) -> int:
             config.startup_command,
             config.python_version,
             config.quiet,
+            config.pyc,
+            config.ignore_file_patterns,
         )
     except SourceDirectoryNotFound as exc:
         error(f"Folder {exc.directory_path!r} does not exist.")

--- a/src/packaged/config.py
+++ b/src/packaged/config.py
@@ -26,6 +26,8 @@ class Config:
     startup_command: str
     python_version: str
     quiet: bool
+    pyc: bool
+    ignore_file_patterns: list[str] | None
 
 
 CONFIG_NAME = "./packaged.toml"

--- a/src/packaged/config.py
+++ b/src/packaged/config.py
@@ -58,6 +58,8 @@ def parse_config(source_directory: str) -> Config:
             config_data["startup_command"],
             config_data.get("python_version", "3.12"),
             config_data.get("quiet", "CI" in os.environ),
+            config_data.get("pyc", False),
+            config_data.get("ignore_file_patterns"),
         )
     except KeyError as exc:
         key = exc.args[0]

--- a/tests/end_to_end/packaged_test.py
+++ b/tests/end_to_end/packaged_test.py
@@ -18,6 +18,7 @@ def build_package(
     output_path: str,
     build_command: str,
     startup_command: str,
+    create_pyc: bool,
 ) -> Iterator[None]:
     """Builds the package, but also delete it afterwards."""
     try:
@@ -27,6 +28,7 @@ def build_package(
             build_command,
             startup_command,
             python_version=packaged.DEFAULT_PYTHON_VERSION,
+            pyc=create_pyc,
         )
         yield
     finally:
@@ -50,14 +52,18 @@ def test_just_python() -> None:
 
 
 def test_numpy_pandas() -> None:
-    """Packages `numpy_pandas` to test packaging the math stack."""
+    """
+    Packages `numpy_pandas` to test packaging the math stack.
+    Also pass `--pyc` to ensure that works too.
+    """
     package_path = os.path.join(TEST_PACKAGES, "numpy_pandas")
     executable_path = "./numpy_pandas.bin"
     with build_package(
         package_path,
         executable_path,
         "pip install numpy pandas",
-        "python somefile.py",
+        "python somefile.pyc",
+        create_pyc=True,
     ):
         assert "0   -2.222222\ndtype: float64" in get_output(executable_path)
 

--- a/tests/end_to_end/packaged_test.py
+++ b/tests/end_to_end/packaged_test.py
@@ -18,7 +18,8 @@ def build_package(
     output_path: str,
     build_command: str,
     startup_command: str,
-    create_pyc: bool,
+    *,
+    create_pyc: bool = False,
 ) -> Iterator[None]:
     """Builds the package, but also delete it afterwards."""
     try:

--- a/tests/end_to_end/test_packages/configtest/setup.py
+++ b/tests/end_to_end/test_packages/configtest/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()


### PR DESCRIPTION
Hi Tushar! I was working with pycify and packaged and ended up integrating both of them.

I tested both the example apps and it should be working, in the process ended up having to 
- Make pycify run with a specific python version (Else python complains about magic number mismatch)
- Ignore files cus setup.py would get replaced

P.s. This requires https://github.com/tusharsadhwani/pycify/pull/1 to be merged

